### PR TITLE
Fixed too old website link

### DIFF
--- a/Calculus_Prob_14041/sample_report_2.tex
+++ b/Calculus_Prob_14041/sample_report_2.tex
@@ -1,7 +1,7 @@
 %From Evaluation of Definite Integral sin^m cos^n dx from 0 to 2pi for Even Number n,m.tex
 %Copyright ⓒ 2015  박승원(seungwonpark), Gyeonggi Science HighSchool for the Gifted. All rights reserved. Email : psw14041@gmail.com
 % Provided by GSHS LaTeX Intro.
-% Website : http://gshslatexintro.github.io/gshslatexintro
+% Website : http://gshslatexintro.github.io
 \documentclass[11pt]{article}
 \usepackage[left=25mm,right=25mm,top=30mm,bottom=30mm]{geometry}
 \usepackage{amsmath} % math


### PR DESCRIPTION
gshslatexintro/gshslatexintro 가 gshslatexintro/gshs-format으로 바뀜으로 인해, 깨져버린 링크를 변경합니다.

gshslatexintro.github.io/gshslatexintro -> gshslatexintro.github.io